### PR TITLE
🐛 핫스팟에서는 DNS 레코드로 주소 변경 & dotenv 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "private": true,
   "packageManager": "pnpm@8.14.3",
   "scripts": {
-    "dev": "next dev",
-    "build": "next build",
+    "dev": "dotenv -e .env.development next dev",
+    "build": "dotenv -e .env.production next build",
     "start": "next start",
     "lint": "next lint",
-    "postinstall": "prisma generate"
+    "postinstall": "dotenv -e .env.development prisma generate",
+    "pull": "dotenv -e .env.development prisma db pull"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.503.1",
@@ -21,6 +22,7 @@
     "autoprefixer": "^10.4.17",
     "axios": "^1.6.7",
     "dotenv": "^16.4.1",
+    "dotenv-cli": "^8.0.0",
     "leva": "^0.9.35",
     "next": "^14.1.0",
     "next-auth": "^4.24.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ dependencies:
   dotenv:
     specifier: ^16.4.1
     version: 16.4.1
+  dotenv-cli:
+    specifier: ^8.0.0
+    version: 8.0.0
   leva:
     specifier: ^0.9.35
     version: 0.9.35(@types/react-dom@18.3.5)(@types/react@18.2.48)(react-dom@18.2.0)(react@18.3.1)
@@ -3170,6 +3173,14 @@ packages:
       which: 2.0.2
     dev: true
 
+  /cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
   /cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -3279,6 +3290,21 @@ packages:
     dependencies:
       esutils: 2.0.3
     dev: true
+
+  /dotenv-cli@8.0.0:
+    resolution: {integrity: sha512-aLqYbK7xKOiTMIRf1lDPbI+Y+Ip/wo5k3eyp6ePysVaSqbyxjyK3dK35BTxG+rmd7djf5q2UPs4noPNH+cj0Qw==}
+    hasBin: true
+    dependencies:
+      cross-spawn: 7.0.6
+      dotenv: 16.4.1
+      dotenv-expand: 10.0.0
+      minimist: 1.2.8
+    dev: false
+
+  /dotenv-expand@10.0.0:
+    resolution: {integrity: sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==}
+    engines: {node: '>=12'}
+    dev: false
 
   /dotenv@16.4.1:
     resolution: {integrity: sha512-CjA3y+Dr3FyFDOAMnxZEGtnW9KBR2M0JvvUtXNW+dYJL5ROWxP9DUHCwgFqpMk0OXCc0ljhaNTr2w/kutYIcHQ==}
@@ -3848,7 +3874,7 @@ packages:
     resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
     engines: {node: '>=14'}
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       signal-exit: 4.1.0
     dev: true
 
@@ -4286,7 +4312,6 @@ packages:
 
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-    dev: true
 
   /isobject@3.0.1:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
@@ -4557,7 +4582,6 @@ packages:
 
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-    dev: true
 
   /minipass@7.0.4:
     resolution: {integrity: sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==}
@@ -4825,7 +4849,6 @@ packages:
   /path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
-    dev: true
 
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -5364,12 +5387,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       shebang-regex: 3.0.0
-    dev: true
 
   /shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
-    dev: true
 
   /side-channel@1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
@@ -5965,7 +5986,6 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
-    dev: true
 
   /wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}

--- a/src/lib/prismadb.ts
+++ b/src/lib/prismadb.ts
@@ -12,6 +12,17 @@ const globalForPrisma = globalThis as unknown as {
 
 const prisma = globalForPrisma.prisma ?? prismaClientSingleton();
 
+async function main() {
+  try {
+    await prisma.$connect();
+  } catch (err) {
+    console.error('❌ DB 연결 실패:', err);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+main();
+
 export default prisma;
 
 if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
> 카페에서 핫스팟으로 db 연동을 시도했는데, 처음엔 env 문제인지 알았으나 CLI로 접속해도 에러가 발생하는 것을 확인
> 

### 원인

DNS 요청이 필터링 되어 SRV 레코드를 반환하지 못함

- DNS 레코드 종류
    
    
    | A | 해당 도메인 주소가 가지는 IP (도메인 ↔ ip 직접 매핑)
    - 한번에 찾아갈 IP 주소를 알 수 있음 |
    | --- | --- |
    | AAAA | A 레코드의 IPv6 버전 |
    | CNAME | 도메인 별명, 또 다른 도메인 주소로 이중 매핑
    - ip가 자주 변경되면 유연하게 대응 가능 |
    | SOA | 인증된 데이터를 가지고 있는지 증명(DNS 핵심 정보)
    - 도메인 당 1개 |
    | CAA | 도메인 인증기관에 관련된 레코드 |
- SRV 레코드
    - DNS 레코드는 IP 주소만 지정하지만, SRV 레코드는 **IP 주소의 포트까지 포함**
    - A레코드 또는 AAAA 레코드를 가리켜야함
    - 서버이름이 CNAME 일 수 없음 ([example.com](http://example.com/) → A 또는 AAAA 레코드로 직접 연결 필)
    - 순서
        1. SRV 레코드로 DNS 요청 보냄
        2. SRV 레코드 조회 ⇒ **클러스터에 속한 여러 서버 주소 + 포트 + 우선순위 + 가중치**를 반환받음  
            → 위 결과를 통해 어떤 호스트에 접속할지, 어떤 포트인지, 어떤 replicaSet으로 구성됐는지 판단
            
        
- DNS 요청
    - UDP 53번 포트를 통해 DNS 요청을 보냄
        - DNS 감시 목적으로 학교, 공공기관 등은 UDP 53번을 막아버림
    - 요청 보내서 IP 주소로 바꿔줌

### 이유 분석

1. 핫스팟이 SRV 쿼리를 처리 못하거나 제한
2. 통신사가 DNS 프록시로 필터링

→ 그래서 `dig` 명령어로 도메인 주소가 차단되어있는지 확인해봤는데, 이건 아닌 것 같았음

**GPT🤖**

- SRV 레코드로 응답된 MongoDB 호스트들은 기본적으로 `27017` 포트를 사용함
- 회사/기관 네트워크에서 이 포트를 차단했을 가능성 큼

### 해결

1. standard connection string 사용하기 (DNS 레코드로 요청 전송)
2. mongodb url 끝에 DB_PATH 붙여주기 (https://github.com/prisma/docs/issues/5562)